### PR TITLE
fix schedule order regression

### DIFF
--- a/public/schedule.json
+++ b/public/schedule.json
@@ -93,8 +93,8 @@
       },
       {
         "time": "11:05 AM",
-        "title": "Reactive all the things",
-        "author": "Ben Lesh &amp; Martin Gontovnikas"
+        "title": "Fast from the Start",
+        "author": "Jeff Cross"
       },
       {
         "time": "11:30 AM",
@@ -213,8 +213,8 @@
       },
       {
         "time": "11:30 AM",
-        "title": "Fast from the Start",
-        "author": "Jeff Cross"
+        "title": "Reactive all the things",
+        "author": "Ben Lesh &amp; Martin Gontovnikas"
       },
       {
         "time": "11:50 AM",


### PR DESCRIPTION
My talk should ideally be the first day before lunch since other talks depend on it. Especially the ngTasty talk.
